### PR TITLE
Add SPDX license headers to workflows and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Winni Neessen <wn@neessen.dev>
+#
+# SPDX-License-Identifier: MIT
+
 version: 2
 updates:
   - package-ecosystem: github-actions

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Winni Neessen <wn@neessen.dev>
+#
+# SPDX-License-Identifier: MIT
+
 # For most projects, this workflow file will not need changing; you simply need
 # to commit it to your repository.
 #

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023 Winni Neessen <wn@neessen.dev>
 #
 # SPDX-License-Identifier: MIT
-#
+
 # Dependency Review Action
 #
 # This Action will scan dependency manifest files that change as part of a Pull Request,


### PR DESCRIPTION
Added SPDX license headers to the GitHub workflows and the Dependabot configuration file, specifying the license as MIT. Also, minor formatting changes have been made to the dependency review workflow file.